### PR TITLE
Update get_grid_* functions to use grid id

### DIFF
--- a/.bmi/api.yaml
+++ b/.bmi/api.yaml
@@ -1,0 +1,16 @@
+name: Storm
+language: c
+
+register: register_bmi_storm
+includes:
+  - "#include <bmi/bmi_storm.h>"
+  - "#include <bmi/bmilib.h>"
+cflags:
+  pkgconfig: storm
+libs:
+  pkgconfig: storm
+
+build:
+  brew:
+    formula: csdms/models/storm
+    options: "--HEAD"

--- a/.bmi/info.yaml
+++ b/.bmi/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/csdms-contrib/storm
+author: Rudy Slingerland
+email: sling@geosc.psu.edu
+version: 0.1-bmi

--- a/.bmi/parameters.yaml
+++ b/.bmi/parameters.yaml
@@ -1,0 +1,143 @@
+%YAML 1.2
+---
+run_duration:
+  description: Simulation run time
+  value:
+    type: float
+    default: 30.0
+    units: d
+    range:
+      min: 1
+      max: 1000000
+---
+number_of_rows:
+  name: Number of rows
+  description: Number of grid rows
+  value:
+    type: int
+    default: 50
+    range:
+      min: 7
+      max: 2147483647
+    units: -
+
+number_of_columns:
+  name: Number of columns
+  description: Number of grid columns
+  value:
+    type: int
+    default: 50
+    range:
+      min: 7
+      max: 2147483647
+    units: -
+
+grid_spacing_row:
+  name: Grid row spacing
+  description: Grid resolution in northerly (row) direction
+  value:
+    type: float
+    default: 10000.0
+    range:
+      min: 1.0
+      max: 1.79769e308
+    units: -
+
+grid_spacing_col:
+  name: Grid column spacing
+  description: Grid resolution in easterly (column) direction
+  value:
+    type: float
+    default: 10000.0
+    range:
+      min: 1.0
+      max: 1.79769e308
+    units: -
+
+center_row_node:
+  name: Row node of center
+  description: Grid row of storm center
+  value:
+    type: int
+    default: 25
+    range:
+      min: 1
+      max: 2147483647
+    units: -
+
+center_col_node:
+  name: Column node of center
+  description: Grid column of storm center
+  value:
+    type: int
+    default: 25
+    range:
+      min: 1
+      max: 2147483647
+    units: -
+---
+storm_speed:
+  name: Storm speed
+  description: Propagation speed of storm
+  value:
+    type: float
+    default: 5.0
+    range:
+      min: 0.0
+      max: 1.79769e308
+    units: m/s
+
+storm_direction:
+  name: Storm direction
+  description: Direction of storm propagation (CCW from east)
+  value:
+    type: float
+    default: 180.0
+    range:
+      min: 0.0
+      max: 360.0
+    units: deg
+
+pressure_center:
+  name: Central pressure
+  description: Atmospheric pressure at center of storm
+  value:
+    type: float
+    default: 99800.0
+    range:
+      min: 0.0
+      max: 1.79769e308
+    units: Pa
+
+pressure_edge:
+  name: Edge pressure
+  description: Atmospheric pressure at edge of storm
+  value:
+    type: float
+    default: 101300.0
+    range:
+      min: 0.0
+      max: 1.79769e308
+    units: Pa
+
+storm_radius:
+  name: Storm radius
+  description: Radius of storm
+  value:
+    type: float
+    default: 1.0e6
+    range:
+      min: 0.0
+      max: 1.79769e308
+    units: m
+
+radius_of_maximum_winds:
+  name: Radius of maximum winds
+  description: Radius of maximum storm winds
+  value:
+    type: float
+    default: 24400.0
+    range:
+      min: 0.0
+      max: 1.79769e308
+    units: m

--- a/.bmi/storm.in.tmpl
+++ b/.bmi/storm.in.tmpl
@@ -1,0 +1,5 @@
+{run_duration} {number_of_rows} {number_of_columns} {grid_spacing_row} {grid_spacing_col} # t_end, shape(i,j), spacing(x,y)
+
+{center_row_node} {center_col_node} # center(i,j)
+{storm_speed} {storm_direction} {pressure_center} {pressure_edge} # sspd, sdir, pcent, pedge
+{radius_of_maximum_winds} {storm_radius} # rmaxw, srad

--- a/bmi/bmi.c
+++ b/bmi/bmi.c
@@ -93,6 +93,11 @@ int BMI_Get_end_time(BMI_Model* model, double * time) {
 }
 
 
+int BMI_Get_var_grid(BMI_Model * model, const char * name, int * grid) {
+  call_bmi_and_return(model, get_var_grid, name, grid);
+}
+
+
 int BMI_Get_var_type(BMI_Model * model, const char * name, char * type) {
   call_bmi_and_return(model, get_var_type, name, type);
 }
@@ -103,84 +108,78 @@ int BMI_Get_var_units(BMI_Model * model, const char * name, char * units) {
 }
 
 
-int BMI_Get_var_rank(BMI_Model * model, const char * name, int * rank) {
-  call_bmi_and_return(model, get_var_rank, name, rank);
-}
-
-
-int BMI_Get_var_size(BMI_Model * model, const char * name, int * size) {
-  call_bmi_and_return(model, get_var_size, name, size);
-}
-
-
 int BMI_Get_var_nbytes(BMI_Model * model, const char * name, int * nbytes) {
   call_bmi_and_return(model, get_var_nbytes, name, nbytes);
 }
 
 
-int BMI_Get_grid_type(BMI_Model * model, const char * name, char * type) {
-  call_bmi_and_return(model, get_grid_type, name, type);
+int BMI_Get_grid_rank(BMI_Model * model, int grid, int * rank) {
+  call_bmi_and_return(model, get_grid_rank, grid, rank);
 }
 
 
-int BMI_Get_grid_shape(BMI_Model * model, const char * name, int * shape) {
-  call_bmi_and_return(model, get_grid_shape, name, shape);
+int BMI_Get_grid_size(BMI_Model * model, int grid, int * size) {
+  call_bmi_and_return(model, get_grid_size, grid, size);
 }
 
 
-int BMI_Get_grid_spacing(BMI_Model * model, const char * name,
-    double * spacing) {
-  call_bmi_and_return(model, get_grid_spacing, name, spacing);
+int BMI_Get_grid_type(BMI_Model * model, int grid, char * type) {
+  call_bmi_and_return(model, get_grid_type, grid, type);
 }
 
 
-int BMI_Get_grid_origin(BMI_Model * model, const char * name,
-    double * origin) {
-  call_bmi_and_return(model, get_grid_origin, name, origin);
+int BMI_Get_grid_shape(BMI_Model * model, int grid, int * shape) {
+  call_bmi_and_return(model, get_grid_shape, grid, shape);
 }
 
 
-int BMI_Get_grid_x(BMI_Model * model, const char * name, double * x) {
-  call_bmi_and_return(model, get_grid_x, name, x);
+int BMI_Get_grid_spacing(BMI_Model * model, int grid, double * spacing) {
+  call_bmi_and_return(model, get_grid_spacing, grid, spacing);
 }
 
 
-int BMI_Get_grid_y(BMI_Model * model, const char * name, double * y) {
-  call_bmi_and_return(model, get_grid_y, name, y);
+int BMI_Get_grid_origin(BMI_Model * model, int grid, double * origin) {
+  call_bmi_and_return(model, get_grid_origin, grid, origin);
 }
 
 
-int BMI_Get_grid_z(BMI_Model * model, const char * name, double * z) {
-  call_bmi_and_return(model, get_grid_z, name, z);
+int BMI_Get_grid_x(BMI_Model * model, int grid, double * x) {
+  call_bmi_and_return(model, get_grid_x, grid, x);
 }
 
 
-int BMI_Get_grid_cell_count(BMI_Model * model, const char * name,
-    int * n_cells) {
-  call_bmi_and_return(model, get_grid_cell_count, name, n_cells);
+int BMI_Get_grid_y(BMI_Model * model, int grid, double * y) {
+  call_bmi_and_return(model, get_grid_y, grid, y);
 }
 
 
-int BMI_Get_grid_point_count(BMI_Model * model, const char * name,
-    int * n_points) {
-  call_bmi_and_return(model, get_grid_point_count, name, n_points);
+int BMI_Get_grid_z(BMI_Model * model, int grid, double * z) {
+  call_bmi_and_return(model, get_grid_z, grid, z);
 }
 
 
-int BMI_Get_grid_vertex_count(BMI_Model * model, const char * name,
-    int * n_verts) {
-  call_bmi_and_return(model, get_grid_vertex_count, name, n_verts);
+int BMI_Get_grid_cell_count(BMI_Model * model, int grid, int * n_cells) {
+  call_bmi_and_return(model, get_grid_cell_count, grid, n_cells);
 }
 
 
-int BMI_Get_grid_connectivity(BMI_Model * model, const char * name,
-    int * connectivity) {
-  call_bmi_and_return(model, get_grid_connectivity, name, connectivity);
+int BMI_Get_grid_point_count(BMI_Model * model, int grid, int * n_points) {
+  call_bmi_and_return(model, get_grid_point_count, grid, n_points);
 }
 
 
-int BMI_Get_grid_offset(BMI_Model * model, const char * name, int * offset) {
-  call_bmi_and_return(model, get_grid_offset, name, offset);
+int BMI_Get_grid_vertex_count(BMI_Model * model, int grid, int * n_verts) {
+  call_bmi_and_return(model, get_grid_vertex_count, grid, n_verts);
+}
+
+
+int BMI_Get_grid_connectivity(BMI_Model * model, int grid, int * connectivity) {
+  call_bmi_and_return(model, get_grid_connectivity, grid, connectivity);
+}
+
+
+int BMI_Get_grid_offset(BMI_Model * model, int grid, int * offset) {
+  call_bmi_and_return(model, get_grid_offset, grid, offset);
 }
 
 

--- a/bmi/bmi.h
+++ b/bmi/bmi.h
@@ -30,10 +30,9 @@ typedef struct {
   int (* get_input_var_names)(void *, char **);
   int (* get_output_var_names)(void *, char **);
 
+  int (* get_var_grid)(void *, const char *, int *);
   int (* get_var_type)(void *, const char *, char *);
   int (* get_var_units)(void *, const char *, char *);
-  int (* get_var_rank)(void *, const char *, int *);
-  int (* get_var_size)(void *, const char *, int *);
   int (* get_var_nbytes)(void *, const char *, int *);
   int (* get_current_time)(void *, double *);
   int (* get_start_time)(void *, double *);
@@ -51,21 +50,23 @@ typedef struct {
   int (* set_value_at_indices)(void *, const char *, int *, int, void *);
 
   /* Grid information functions */
-  int (* get_grid_type)(void *, const char *, char *);
-  int (* get_grid_shape)(void *, const char *, int *);
-  int (* get_grid_spacing)(void *, const char *, double *);
-  int (* get_grid_origin)(void *, const char *, double *);
+  int (* get_grid_size)(void *, int, int *);
+  int (* get_grid_rank)(void *, int, int *);
+  int (* get_grid_type)(void *, int, char *);
+  int (* get_grid_shape)(void *, int, int *);
+  int (* get_grid_spacing)(void *, int, double *);
+  int (* get_grid_origin)(void *, int, double *);
 
-  int (* get_grid_x)(void *, const char *, double *);
-  int (* get_grid_y)(void *, const char *, double *);
-  int (* get_grid_z)(void *, const char *, double *);
+  int (* get_grid_x)(void *, int, double *);
+  int (* get_grid_y)(void *, int, double *);
+  int (* get_grid_z)(void *, int, double *);
 
-  int (* get_grid_cell_count)(void *, const char *, int *);
-  int (* get_grid_point_count)(void *, const char *, int *);
-  int (* get_grid_vertex_count)(void *, const char *, int *);
+  int (* get_grid_cell_count)(void *, int, int *);
+  int (* get_grid_point_count)(void *, int, int *);
+  int (* get_grid_vertex_count)(void *, int, int *);
 
-  int (* get_grid_connectivity)(void *, const char *, int *);
-  int (* get_grid_offset)(void *, const char *, int *);
+  int (* get_grid_connectivity)(void *, int, int *);
+  int (* get_grid_offset)(void *, int, int *);
 } BMI_Model;
 
 

--- a/bmi/bmi_storm.c
+++ b/bmi/bmi_storm.c
@@ -224,6 +224,37 @@ Get_var_units (void *self, const char *name, char *units)
 
 
 static int
+Get_var_nbytes (void *self, const char *name, int *nbytes)
+{
+  int size = 0;
+  int grid;
+  char type[BMI_MAX_TYPE_NAME];
+
+  *nbytes = -1;
+
+  if (Get_var_grid (self, name, &grid) == BMI_FAILURE)
+    return BMI_FAILURE;
+
+  if (Get_grid_size (self, grid, &size) == BMI_FAILURE)
+    return BMI_FAILURE;
+
+  if (Get_var_type (self, name, type) == BMI_FAILURE)
+    return BMI_FAILURE;
+
+  if (strcmp (type, "int") == 0) {
+    *nbytes = sizeof (int) * size;
+    return BMI_SUCCESS;
+  } else if (strcmp (type, "double") == 0) {
+    *nbytes = sizeof (double) * size;
+    return BMI_SUCCESS;
+  }
+  else {
+    return BMI_FAILURE;
+  }
+}
+
+
+static int
 Get_grid_rank (void *self, int grid, int *rank)
 {
   if (grid == 0) {
@@ -254,38 +285,6 @@ Get_grid_size (void *self, int grid, int *size)
     *size = -1;
     return BMI_FAILURE;
   }
-}
-
-
-static int
-Get_var_nbytes (void *self, const char *name, int *nbytes)
-{
-  int status = BMI_SUCCESS;
-
-  {
-    int size = 0;
-    char type[BMI_MAX_TYPE_NAME];
-
-    status = Get_var_size (self, name, &size);
-    if (status == BMI_FAILURE)
-      return status;
-
-    status = Get_var_type (self, name, type);
-    if (status == BMI_FAILURE)
-      return status;
-
-    if (strcmp (type, "int") == 0) {
-      *nbytes = sizeof (int) * size;
-    } else if (strcmp (type, "double") == 0) {
-      *nbytes = sizeof (double) * size;
-    } 
-    else {
-      *nbytes = -1;
-      status = BMI_FAILURE;
-    }
-  }
-
-  return status;
 }
 
 

--- a/bmi/bmi_storm.c
+++ b/bmi/bmi_storm.c
@@ -290,59 +290,38 @@ Get_var_nbytes (void *self, const char *name, int *nbytes)
 
 
 static int
-Get_grid_shape (void *self, const char *name, int *shape)
+Get_grid_shape (void *self, int grid, int *shape)
 {
-  int status = BMI_SUCCESS;
-
-  if ((strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) ||
-      (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0)) {
+  if (grid == 0) {
     shape[0] = ((StormModel *)self)->shape[0];
     shape[1] = ((StormModel *)self)->shape[1];
   }
-  else {
-    *shape = -1;
-    status = BMI_FAILURE;
-  }
 
-  return status;
+  return BMI_SUCCESS;
 }
 
 
 static int
-Get_grid_spacing (void *self, const char *name, double *spacing)
+Get_grid_spacing (void *self, int grid, double *spacing)
 {
-  int status = BMI_SUCCESS;
-
-  if ((strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) ||
-      (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0)) {
+  if (grid == 0) {
     spacing[0] = ((StormModel *)self)->spacing[0];
     spacing[1] = ((StormModel *)self)->spacing[1];
   }
-  else {
-    *spacing = -1.0;
-    status = BMI_FAILURE;
-  }
 
-  return status;
+  return BMI_SUCCESS;
 }
 
 
 static int
-Get_grid_origin (void *self, const char *name, double *origin)
+Get_grid_origin (void *self, int grid, double *origin)
 {
-  int status = BMI_SUCCESS;
-
-  if ((strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) ||
-      (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0)) {
+  if (grid == 0) {
     origin[0] = 0.0;
     origin[1] = 0.0;
   }
-  else {
-    *origin = -1.0;
-    status = BMI_FAILURE;
-  }
 
-  return status;
+  return BMI_SUCCESS;
 }
 
 

--- a/bmi/bmi_storm.c
+++ b/bmi/bmi_storm.c
@@ -326,13 +326,14 @@ Get_grid_origin (void *self, int grid, double *origin)
 
 
 static int
-Get_grid_type (void *self, const char *name, char *type)
+Get_grid_type (void *self, int grid, char *type)
 {
   int status = BMI_SUCCESS;
 
-  if ((strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) ||
-      (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0)) {
+  if (grid == 0) {
     strncpy(type, "uniform_rectilinear", BMI_MAX_TYPE_NAME);
+  } else if (grid == 1) {
+    strncpy(type, "scalar", BMI_MAX_TYPE_NAME);
   }
   else {
     type[0] = '\0';

--- a/bmi/bmi_storm.c
+++ b/bmi/bmi_storm.c
@@ -407,6 +407,47 @@ Get_grid_type (void *self, const char *name, char *type)
 
 
 static int
+Get_var_grid (void *self, const char *name, int *grid)
+{
+  if (strcmp (name, "model_grid_cell__row_index") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "model_grid_cell__column_index") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "cyclone__magnitude_of_velocity") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "cyclone__azimuth_angle_of_velocity") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "atmosphere_bottom_air__pressure") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "atmosphere_bottom_air__reference_pressure") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "cyclone_air_flow_max_speed__radius") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "cyclone__radius") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) {
+    *grid = 0;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0) {
+    *grid = 0;
+    return BMI_SUCCESS;
+  }
+  else {
+    *grid = -1;
+    return BMI_FAILURE;
+  }
+}
+
+
+static int
 Get_value_ptr (void *self, const char *name, void **dest)
 {
   int status = BMI_FAILURE;

--- a/bmi/bmi_storm.c
+++ b/bmi/bmi_storm.c
@@ -594,7 +594,7 @@ Get_component_name (void *self, char *name)
 
 
 BMI_Model *
-Construct_storm_bmi(BMI_Model *model)
+register_bmi_storm (BMI_Model *model)
 {
   if (model) {
     model->self = NULL;

--- a/bmi/bmi_storm.c
+++ b/bmi/bmi_storm.c
@@ -142,6 +142,136 @@ Finalize (void *self)
 
 
 static int
+Get_grid_rank (void *self, int grid, int *rank)
+{
+  if (grid == 0) {
+    *rank = 2;
+    return BMI_SUCCESS;
+  } else if (grid == 1) {
+    *rank = 0;
+    return BMI_SUCCESS;
+  }
+  else {
+    *rank = -1;
+    return BMI_FAILURE;
+  }
+}
+
+
+static int
+Get_grid_size (void *self, int grid, int *size)
+{
+  if (grid == 0) {
+    *size = ((StormModel *)self)->shape[0] * ((StormModel *)self)->shape[1];
+    return BMI_SUCCESS;
+  } else if (grid == 1) {
+    *size = 1;
+    return BMI_SUCCESS;
+  }
+  else {
+    *size = -1;
+    return BMI_FAILURE;
+  }
+}
+
+
+static int
+Get_grid_shape (void *self, int grid, int *shape)
+{
+  if (grid == 0) {
+    shape[0] = ((StormModel *)self)->shape[0];
+    shape[1] = ((StormModel *)self)->shape[1];
+  }
+
+  return BMI_SUCCESS;
+}
+
+
+static int
+Get_grid_spacing (void *self, int grid, double *spacing)
+{
+  if (grid == 0) {
+    spacing[0] = ((StormModel *)self)->spacing[0];
+    spacing[1] = ((StormModel *)self)->spacing[1];
+  }
+
+  return BMI_SUCCESS;
+}
+
+
+static int
+Get_grid_origin (void *self, int grid, double *origin)
+{
+  if (grid == 0) {
+    origin[0] = 0.0;
+    origin[1] = 0.0;
+  }
+
+  return BMI_SUCCESS;
+}
+
+
+static int
+Get_grid_type (void *self, int grid, char *type)
+{
+  int status = BMI_SUCCESS;
+
+  if (grid == 0) {
+    strncpy(type, "uniform_rectilinear", BMI_MAX_TYPE_NAME);
+  } else if (grid == 1) {
+    strncpy(type, "scalar", BMI_MAX_TYPE_NAME);
+  }
+  else {
+    type[0] = '\0';
+    status = BMI_FAILURE;
+  }
+
+  return status;
+}
+
+
+/* The output 2D wind fields are assigned an id of 0. */
+/* The input parameters are scalars, and are assigned an id of 1. */
+static int
+Get_var_grid (void *self, const char *name, int *grid)
+{
+  if ((strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) || 
+      (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0)) {
+    *grid = 0;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "model_grid_cell__row_index") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "model_grid_cell__column_index") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "cyclone__magnitude_of_velocity") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "cyclone__azimuth_angle_of_velocity") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "atmosphere_bottom_air__pressure") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "atmosphere_bottom_air__reference_pressure") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "cyclone_air_flow_max_speed__radius") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "cyclone__radius") == 0) {
+    *grid = 1;
+    return BMI_SUCCESS;
+  }
+  else {
+    *grid = -1;
+    return BMI_FAILURE;
+  }
+}
+
+
+static int
 Get_var_type (void *self, const char *name, char *type)
 {
   if (strcmp (name, "model_grid_cell__row_index") == 0) {
@@ -249,137 +379,6 @@ Get_var_nbytes (void *self, const char *name, int *nbytes)
     return BMI_SUCCESS;
   }
   else {
-    return BMI_FAILURE;
-  }
-}
-
-
-static int
-Get_grid_rank (void *self, int grid, int *rank)
-{
-  if (grid == 0) {
-    *rank = 2;
-    return BMI_SUCCESS;
-  } else if (grid == 1) {
-    *rank = 0;
-    return BMI_SUCCESS;
-  }
-  else {
-    *rank = -1;
-    return BMI_FAILURE;
-  }
-}
-
-
-static int
-Get_grid_size (void *self, int grid, int *size)
-{
-  if (grid == 0) {
-    *size = ((StormModel *)self)->shape[0] * ((StormModel *)self)->shape[1];
-    return BMI_SUCCESS;
-  } else if (grid == 1) {
-    *size = 1;
-    return BMI_SUCCESS;
-  }
-  else {
-    *size = -1;
-    return BMI_FAILURE;
-  }
-}
-
-
-static int
-Get_grid_shape (void *self, int grid, int *shape)
-{
-  if (grid == 0) {
-    shape[0] = ((StormModel *)self)->shape[0];
-    shape[1] = ((StormModel *)self)->shape[1];
-  }
-
-  return BMI_SUCCESS;
-}
-
-
-static int
-Get_grid_spacing (void *self, int grid, double *spacing)
-{
-  if (grid == 0) {
-    spacing[0] = ((StormModel *)self)->spacing[0];
-    spacing[1] = ((StormModel *)self)->spacing[1];
-  }
-
-  return BMI_SUCCESS;
-}
-
-
-static int
-Get_grid_origin (void *self, int grid, double *origin)
-{
-  if (grid == 0) {
-    origin[0] = 0.0;
-    origin[1] = 0.0;
-  }
-
-  return BMI_SUCCESS;
-}
-
-
-static int
-Get_grid_type (void *self, int grid, char *type)
-{
-  int status = BMI_SUCCESS;
-
-  if (grid == 0) {
-    strncpy(type, "uniform_rectilinear", BMI_MAX_TYPE_NAME);
-  } else if (grid == 1) {
-    strncpy(type, "scalar", BMI_MAX_TYPE_NAME);
-  }
-  else {
-    type[0] = '\0';
-    status = BMI_FAILURE;
-  }
-
-  return status;
-}
-
-/*
-   The output 2D wind fields are assigned an id of 0; the input
-   parameters are scalars, and are assigned an id of 1.
-*/
-static int
-Get_var_grid (void *self, const char *name, int *grid)
-{
-  if ((strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) || 
-      (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0)) {
-    *grid = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "model_grid_cell__row_index") == 0) {
-    *grid = 1;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "model_grid_cell__column_index") == 0) {
-    *grid = 1;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "cyclone__magnitude_of_velocity") == 0) {
-    *grid = 1;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "cyclone__azimuth_angle_of_velocity") == 0) {
-    *grid = 1;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "atmosphere_bottom_air__pressure") == 0) {
-    *grid = 1;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "atmosphere_bottom_air__reference_pressure") == 0) {
-    *grid = 1;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "cyclone_air_flow_max_speed__radius") == 0) {
-    *grid = 1;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "cyclone__radius") == 0) {
-    *grid = 1;
-    return BMI_SUCCESS;
-  }
-  else {
-    *grid = -1;
     return BMI_FAILURE;
   }
 }
@@ -591,10 +590,9 @@ register_bmi_storm (BMI_Model *model)
     model->get_input_var_names = Get_input_var_names;
     model->get_output_var_names = Get_output_var_names;
 
+    model->get_var_grid = Get_var_grid;
     model->get_var_type = Get_var_type;
     model->get_var_units = Get_var_units;
-    model->get_var_rank = Get_var_rank;
-    model->get_var_size = Get_var_size;
     model->get_var_nbytes = Get_var_nbytes;
     model->get_current_time = Get_current_time;
     model->get_start_time = Get_start_time;
@@ -610,6 +608,8 @@ register_bmi_storm (BMI_Model *model)
     model->set_value_ptr = NULL;
     model->set_value_at_indices = Set_value_at_indices;
 
+    model->get_grid_size = Get_grid_size;
+    model->get_grid_rank = Get_grid_rank;
     model->get_grid_type = Get_grid_type;
     model->get_grid_shape = Get_grid_shape;
     model->get_grid_spacing = Get_grid_spacing;

--- a/bmi/bmi_storm.c
+++ b/bmi/bmi_storm.c
@@ -363,11 +363,18 @@ Get_grid_type (void *self, const char *name, char *type)
   return status;
 }
 
-
+/*
+   The output 2D wind fields are assigned an id of 0; the input
+   parameters are scalars, and are assigned an id of 1.
+*/
 static int
 Get_var_grid (void *self, const char *name, int *grid)
 {
-  if (strcmp (name, "model_grid_cell__row_index") == 0) {
+  if ((strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) || 
+      (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0)) {
+    *grid = 0;
+    return BMI_SUCCESS;
+  } else if (strcmp (name, "model_grid_cell__row_index") == 0) {
     *grid = 1;
     return BMI_SUCCESS;
   } else if (strcmp (name, "model_grid_cell__column_index") == 0) {
@@ -390,12 +397,6 @@ Get_var_grid (void *self, const char *name, int *grid)
     return BMI_SUCCESS;
   } else if (strcmp (name, "cyclone__radius") == 0) {
     *grid = 1;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) {
-    *grid = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0) {
-    *grid = 0;
     return BMI_SUCCESS;
   }
   else {

--- a/bmi/bmi_storm.c
+++ b/bmi/bmi_storm.c
@@ -224,37 +224,13 @@ Get_var_units (void *self, const char *name, char *units)
 
 
 static int
-Get_var_rank (void *self, const char *name, int *rank)
+Get_grid_rank (void *self, int grid, int *rank)
 {
-  if (strcmp (name, "model_grid_cell__row_index") == 0) {
-    *rank = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "model_grid_cell__column_index") == 0) {
-    *rank = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "cyclone__magnitude_of_velocity") == 0) {
-    *rank = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "cyclone__azimuth_angle_of_velocity") == 0) {
-    *rank = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "atmosphere_bottom_air__pressure") == 0) {
-    *rank = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "atmosphere_bottom_air__reference_pressure") == 0) {
-    *rank = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "cyclone_air_flow_max_speed__radius") == 0) {
-    *rank = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "cyclone__radius") == 0) {
-    *rank = 0;
-    return BMI_SUCCESS;
-  } else if (strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) {
+  if (grid == 0) {
     *rank = 2;
     return BMI_SUCCESS;
-  } else if (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0) {
-    *rank = 2;
+  } else if (grid == 1) {
+    *rank = 0;
     return BMI_SUCCESS;
   }
   else {
@@ -265,37 +241,19 @@ Get_var_rank (void *self, const char *name, int *rank)
 
 
 static int
-Get_var_size (void *self, const char *name, int *size)
+Get_grid_size (void *self, int grid, int *size)
 {
-  int status = BMI_SUCCESS;
-
-  if (strcmp (name, "model_grid_cell__row_index") == 0) {
-    *size = 1;
-  } else if (strcmp (name, "model_grid_cell__column_index") == 0) {
-    *size = 1;
-  } else if (strcmp (name, "cyclone__magnitude_of_velocity") == 0) {
-    *size = 1;
-  } else if (strcmp (name, "cyclone__azimuth_angle_of_velocity") == 0) {
-    *size = 1;
-  } else if (strcmp (name, "atmosphere_bottom_air__pressure") == 0) {
-    *size = 1;
-  } else if (strcmp (name, "atmosphere_bottom_air__reference_pressure") == 0) {
-    *size = 1;
-  } else if (strcmp (name, "cyclone_air_flow_max_speed__radius") == 0) {
-    *size = 1;
-  } else if (strcmp (name, "cyclone__radius") == 0) {
-    *size = 1;
-  } else if (strcmp (name, "atmosphere_air_flow__east_component_of_velocity") == 0) {
+  if (grid == 0) {
     *size = ((StormModel *)self)->shape[0] * ((StormModel *)self)->shape[1];
-  } else if (strcmp (name, "atmosphere_air_flow__north_component_of_velocity") == 0) {
-    *size = ((StormModel *)self)->shape[0] * ((StormModel *)self)->shape[1];
+    return BMI_SUCCESS;
+  } else if (grid == 1) {
+    *size = 1;
+    return BMI_SUCCESS;
   }
   else {
     *size = -1;
-    status = BMI_FAILURE;
+    return BMI_FAILURE;
   }
-
-  return status;
 }
 
 

--- a/bmi/bmi_storm.h
+++ b/bmi/bmi_storm.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include "bmi.h"
 
-BMI_Model* Construct_storm_bmi(BMI_Model *model);
+BMI_Model* register_bmi_storm(BMI_Model *model);
 
 #if defined(__cplusplus)
 }

--- a/bmi/bmilib.h
+++ b/bmi/bmilib.h
@@ -27,10 +27,9 @@ int BMI_Get_current_time(BMI_Model*, double *);
 int BMI_Get_start_time(BMI_Model*, double *);
 int BMI_Get_end_time(BMI_Model*, double *);
 
+int BMI_Get_var_grid(BMI_Model * model, const char * name, int * grid);
 int BMI_Get_var_type(BMI_Model * model, const char * name, char * type);
 int BMI_Get_var_units(BMI_Model * model, const char * name, char * units);
-int BMI_Get_var_rank(BMI_Model * model, const char * name, int * rank);
-int BMI_Get_var_size(BMI_Model * model, const char * name, int * rank);
 int BMI_Get_var_nbytes(BMI_Model * model, const char * name, int * nbytes);
 
 int BMI_Get_value(BMI_Model *, const char *, void *);
@@ -41,22 +40,25 @@ int BMI_Set_value(BMI_Model *, const char *, void *);
 int BMI_Set_value_ptr(BMI_Model *, const char *, void **);
 int BMI_Set_value_at_indices(BMI_Model *, const char *, int *, int, void *);
 
-int BMI_Get_grid_type(BMI_Model * model, const char * name, char * type);
-int BMI_Get_grid_shape(BMI_Model * model, const char * name, int * shape);
-int BMI_Get_grid_spacing(BMI_Model * model, const char * name, double * spacing);
-int BMI_Get_grid_origin(BMI_Model * model, const char * name, double * origin);
+int BMI_Get_grid_rank(BMI_Model * model, int grid, int * rank);
+int BMI_Get_grid_size(BMI_Model * model, int grid, int * rank);
+int BMI_Get_grid_type(BMI_Model * model, int grid, char * type);
+int BMI_Get_grid_shape(BMI_Model * model, int grid, int * shape);
+int BMI_Get_grid_spacing(BMI_Model * model, int grid, double * spacing);
+int BMI_Get_grid_origin(BMI_Model * model, int grid, double * origin);
 
-int BMI_Get_grid_x(BMI_Model * model, const char * name, double * x);
-int BMI_Get_grid_y(BMI_Model * model, const char * name, double * y);
-int BMI_Get_grid_z(BMI_Model * model, const char * name, double * z);
+int BMI_Get_grid_x(BMI_Model * model, int grid, double * x);
+int BMI_Get_grid_y(BMI_Model * model, int grid, double * y);
+int BMI_Get_grid_z(BMI_Model * model, int grid, double * z);
 
-int BMI_Get_grid_cell_count(BMI_Model * model, const char * name, int * n_cells);
-int BMI_Get_grid_point_count(BMI_Model * model, const char * name, int * n_points);
-int BMI_Get_grid_vertex_count(BMI_Model * model, const char * name, int * n_verts);
+int BMI_Get_grid_cell_count(BMI_Model * model, int grid, int * n_cells);
+int BMI_Get_grid_point_count(BMI_Model * model, int grid, int * n_points);
+int BMI_Get_grid_vertex_count(BMI_Model * model, int grid, int * n_verts);
 
-int BMI_Get_grid_connectivity(BMI_Model * model, const char * name, int * connectivity);
-int BMI_Get_grid_offset(BMI_Model * model, const char * name, int * offset);
+int BMI_Get_grid_connectivity(BMI_Model * model, int grid, int * connectivity);
+int BMI_Get_grid_offset(BMI_Model * model, int grid, int * offset);
 
+BMI_Model * register_bmi_model (const char * file, const char * func);
 
 #if defined(__cplusplus)
 }

--- a/testing/test_get_value.c
+++ b/testing/test_get_value.c
@@ -14,7 +14,7 @@ main (void)
   const int n_steps = 10;
   BMI_Model * model = (BMI_Model *)malloc (sizeof(BMI_Model));
 
-  Construct_storm_bmi (model);
+  register_bmi_storm (model);
 
   BMI_Initialize (model, NULL);
 

--- a/testing/test_get_value.c
+++ b/testing/test_get_value.c
@@ -51,12 +51,15 @@ print_var_values (void *model, const char *var_name)
   int len;
   int rank;
   int *shape;
+  int grid;
+  
+  BMI_Get_var_grid (model, var_name, &grid);
 
-  BMI_Get_var_rank (model, var_name, &rank);
+  BMI_Get_grid_rank (model, grid, &rank);
   fprintf (stderr, "rank = %d\n", rank);
   shape = (int*) malloc (sizeof (int) * rank);
 
-  BMI_Get_grid_shape (model, var_name, shape);
+  BMI_Get_grid_shape (model, grid, shape);
 
   {
     int n;

--- a/testing/test_grid_info.c
+++ b/testing/test_grid_info.c
@@ -82,8 +82,11 @@ void
 print_var_info (BMI_Model *model, const char *var)
 {
   int n_dims = 0;
+  int grid;
 
-  BMI_Get_var_rank (model, var, &n_dims);
+  BMI_Get_var_grid (model, var, &grid);
+
+  BMI_Get_grid_rank (model, grid, &n_dims);
 
   {
     char type[BMI_MAX_TYPE_NAME];
@@ -96,10 +99,10 @@ print_var_info (BMI_Model *model, const char *var)
       spacing = (double*) malloc (sizeof (double)*n_dims);
       origin = (double*) malloc (sizeof (double)*n_dims);
 
-      BMI_Get_grid_type (model, var, type);
-      BMI_Get_grid_shape (model, var, shape);
-      BMI_Get_grid_spacing (model, var, spacing);
-      BMI_Get_grid_origin (model, var, origin);
+      BMI_Get_grid_type (model, grid, type);
+      BMI_Get_grid_shape (model, grid, shape);
+      BMI_Get_grid_spacing (model, grid, spacing);
+      BMI_Get_grid_origin (model, grid, origin);
 
       fprintf (stdout, "\n");
       fprintf (stdout, "Name: %s\n", var);

--- a/testing/test_grid_info.c
+++ b/testing/test_grid_info.c
@@ -13,7 +13,7 @@ main (void)
 {
   BMI_Model *model = (BMI_Model*)malloc (sizeof(BMI_Model));
 
-  Construct_storm_bmi(model);
+  register_bmi_storm (model);
 
   BMI_Initialize (model, NULL);
 

--- a/testing/test_irf.c
+++ b/testing/test_irf.c
@@ -12,7 +12,7 @@ main (void)
   int status = BMI_SUCCESS;
   BMI_Model *model = (BMI_Model *)malloc (sizeof(BMI_Model));
 
-  Construct_storm_bmi(model);
+  register_bmi_storm (model);
 
   {
     fprintf (stdout, "Initializing... ");

--- a/testing/test_print_var_names.c
+++ b/testing/test_print_var_names.c
@@ -11,7 +11,7 @@ main (void)
 {
   BMI_Model * model = (BMI_Model *)malloc (sizeof(BMI_Model));
 
-  Construct_storm_bmi (model);
+  register_bmi_storm (model);
 
   if (BMI_Initialize (model, NULL)!=0 || !model)
     return EXIT_FAILURE;

--- a/testing/test_set_value.c
+++ b/testing/test_set_value.c
@@ -14,7 +14,7 @@ main (void)
   int err = 0;
   BMI_Model * model = (BMI_Model*)malloc (sizeof(BMI_Model));
 
-  Construct_storm_bmi(model);
+  register_bmi_storm (model);
 
   err = BMI_Initialize (model, NULL);
   if (err)

--- a/testing/test_set_value.c
+++ b/testing/test_set_value.c
@@ -32,15 +32,16 @@ main (void)
     int *shape;
     int len = 0;
     int i;
+    int grid;
 
-    BMI_Get_var_rank (model, 
-		      "atmosphere_air_flow__east_component_of_velocity", 
-		      &n_dims);
+    BMI_Get_var_grid (model,
+		      "atmosphere_air_flow__east_component_of_velocity",
+		      &grid);
+
+    BMI_Get_grid_rank (model, grid, &n_dims);
     shape = (int*) malloc (sizeof (int)*n_dims);
 
-    BMI_Get_grid_shape (model, 
-			"atmosphere_air_flow__east_component_of_velocity", 
-			shape);
+    BMI_Get_grid_shape (model, grid, shape);
     for (i = 0, len = 1; i < n_dims; i++)
       len *= shape[i];
 
@@ -99,13 +100,13 @@ print_var_values (void *model, const char *var_name)
   double *var = NULL;
   int n_dims = 0;
   int *shape = NULL;
+  int grid;
 
-  BMI_Get_var_rank (model, var_name, &n_dims);
+  BMI_Get_var_grid (model, var_name, &grid);
+  BMI_Get_grid_rank (model, grid, &n_dims);
   shape = (int*) malloc (sizeof (int)*n_dims);
 
-  BMI_Get_grid_shape (model, 
-		      "atmosphere_air_flow__east_component_of_velocity", 
-		      shape);
+  BMI_Get_grid_shape (model, grid, shape);
   BMI_Get_value_ptr (model, var_name, (void**)(&var));
 
   fprintf (stdout, "Variable: %s\n", var_name);

--- a/testing/test_var_info.c
+++ b/testing/test_var_info.c
@@ -86,12 +86,14 @@ print_var_info (BMI_Model *model, const char *var)
   int n_dims = 0;
   int size = 0;
   int n_bytes = 0;
+  int grid;
 
   BMI_Get_var_type (model, var, type);
   BMI_Get_var_units (model, var, units);
-  BMI_Get_var_rank (model, var, &n_dims);
-  BMI_Get_var_size (model, var, &size);
   BMI_Get_var_nbytes (model, var, &n_bytes);
+  BMI_Get_var_grid (model, var, &grid);
+  BMI_Get_grid_rank (model, grid, &n_dims);
+  BMI_Get_grid_size (model, grid, &size);
 
   fprintf (stdout, "\n");
   fprintf (stdout, "Name: %s\n", var);

--- a/testing/test_var_info.c
+++ b/testing/test_var_info.c
@@ -13,7 +13,7 @@ main (void)
 {
   BMI_Model *model = (BMI_Model*)malloc (sizeof(BMI_Model));
 
-  Construct_storm_bmi(model);
+  register_bmi_storm (model);
 
   BMI_Initialize (model, NULL);
 


### PR DESCRIPTION
Most of the changes in this pull request result from adding the `get_var_grid` function and modifying the `get_grid_*` routines to accept a grid id instead of a variable name. I updated the unit tests to reflect these changes.

I also added a **.bmi** directory to work with @mcflugen's new technique for creating a component.
